### PR TITLE
CS-57 - Create script to clean up cacheops

### DIFF
--- a/cacheops/__init__.py
+++ b/cacheops/__init__.py
@@ -1,5 +1,5 @@
 VERSION = (2, 4, 2)
-CC_VERSION = 'cc1'
+CC_VERSION = 'cc2'
 __version__ = '{}-{}'.format(
     '.'.join(map(str, VERSION if VERSION[-1] else VERSION[:2])), CC_VERSION)
 

--- a/cacheops/lua/gc.lua
+++ b/cacheops/lua/gc.lua
@@ -1,0 +1,28 @@
+local conj_key = ARGV[1]
+local bytes = 0 
+local processed = 1
+local deleted_items = 0
+local deleted_sets = 0
+local errors = 0
+
+for i, key in ipairs(KEYS) do
+    local exists = redis.call('exists', key)
+    processed = processed + 1
+    if exists == 0 then
+        bytes = bytes + string.len(key)
+        deleted_items = deleted_items + 1
+        local response = redis.call('srem', conj_key, key)
+        if response == 0 then
+            errors = errors + 1
+            redis.log(redis.LOG_NOTICE, 'srem ' .. conj_key .. ' ' .. key .. ' ' .. response .. ' ' .. exists)
+        end
+    end
+end
+
+if redis.call('scard', conj_key) == 0 then
+    redis.call('del', conj_key)
+    bytes = bytes + string.len(conj_key)
+    deleted_sets = deleted_sets + 1
+end
+
+return {processed, deleted_items, deleted_sets, errors, bytes}

--- a/cacheops/management/commands/cacheops_lru_gc.py
+++ b/cacheops/management/commands/cacheops_lru_gc.py
@@ -1,0 +1,206 @@
+"""
+If CACHEOPS_LRU is enabled CacheOps will not reap its invalidation structures.
+For example:
+
+    > SCARD conj:auth_user:is_active=true
+    (integer) 2851530
+
+Shows that the set contains about 3m members. Checking one of the keys from the
+set:
+
+    > SSCAN "conj:auth_user:is_active=true" 0 COUNT 10
+    1) "1179648"
+    2)  1) "q:e0ab9bf9f2e1f1475f663bfe8a50269f"
+        2) "q:b09c2d45f348a19578154fcbdd1c07d6"
+        3) "as:6a89b161b51cedb7cea37c8e51480465"
+        4) "q:cc6c466aef5822649fce5ed738646bb4"
+        5) "q:9036ac3b3880fb47f36e37451837eec2"
+        6) "q:5c8903f26de59ba20e47bbf7f0a7e70a"
+        7) "q:8694b66aad2186e03b940580f8d1b00c"
+        8) "q:a083362753b9c5e986f3c10c0dddc19d"
+        9) "q:1e13437f509ab6bb8ad51ab19d30f1d9"
+       10) "q:e19c6b853a0f979bd28f65bc2c705b85"
+       11) "q:5f02f2160186282d111fa18722ece7ed"
+    > EXISTS "q:e0ab9bf9f2e1f1475f663bfe8a50269f"
+    (integer) 0
+
+Shows that the key has been expired by cacheops but has NOT been removed from
+the set. This script will iterate through all the conjuction sets and call
+SREM on the the members that do not exist. If the resulting set has no members
+it is also deleted.
+
+Below is the current output from the `cacheops_lru_gc` when it has completed:
+
+    Processed: 71,349,660
+    Deleted Items: 57,674,051
+    Deleted Sets: 11,637,743
+    Deleted %: 97.14
+    Bytes per second: 89.3KiB
+    Items per second: 2519.46
+    Errors: 0
+    Pages: 12,373,159
+    Freed: 2.4GiB
+    Time: 7h471m59s0.46ms
+
+The `cacheops_top` command will show the top 20 keys with largest values
+(pickled querysets) or the top 20 sets with the most number of members.
+ Depending on whether `--keys` or `--sets` is passed.
+"""
+from __future__ import absolute_import, print_function
+
+
+import json
+import logging
+import sys
+import time
+
+from collections import defaultdict
+from optparse import make_option
+
+from django.conf import settings
+from django.core.management.base import BaseCommand
+
+from cacheops.redis import load_script, redis_client
+from cacheops.management.util import pretty_time_delta, sizeof_fmt
+
+
+logger = logging.getLogger(__name__)
+
+
+def gc_conj_key(conj_key, max_pages, page_size, interval, wait_pages):
+    cursor = 0
+    pages = 0
+    stats = defaultdict(int)
+    start_time = time.time()
+    while True:
+        cursor, members = redis_client.sscan(conj_key, cursor=cursor, count=page_size)
+        response = load_script('gc')(keys=members, args=[conj_key])
+        stats['processed'] += response[0]
+        stats['deleted_items'] += response[1]
+        stats['deleted_sets'] += response[2]
+        stats['errors'] += response[3]
+        stats['bytes'] += response[4]
+        pages += 1
+        if cursor == 0 or (max_pages is not None and max_pages > pages):
+            break
+        if pages % wait_pages:
+            time.sleep(interval)
+    stats['runtime'] = time.time() - start_time
+    stats['pages'] = pages
+    return stats
+
+
+def gc(max_pages, page_size, interval, verbosity, wait_pages):
+    cursor = 0
+    pages = 0
+    stats = defaultdict(int)
+    start_time = time.time()
+    while True:
+        cursor, conj_keys = redis_client.scan(cursor=cursor, match='conj:*', count=page_size)
+        for conj_key in conj_keys:
+            conj_stats = gc_conj_key(conj_key, pages, page_size, interval, wait_pages)
+            stats['processed'] += conj_stats['processed']
+            stats['deleted_items'] += conj_stats['deleted_items']
+            stats['deleted_sets'] += conj_stats['deleted_sets']
+            stats['errors'] += conj_stats['errors']
+            stats['bytes'] += conj_stats['bytes']
+            stats['runtime'] = time.time() - start_time
+            stats['bps'] = stats['bytes'] / float(stats['runtime'])
+            stats['ips'] = stats['processed'] / float(stats['runtime'])
+            stats['pages'] += conj_stats['pages']
+        pages += 1
+        if verbosity and pages % 100:
+            print_stats(stats)
+        if cursor == 0 or (max_pages is not None and max_pages > pages):
+            break
+    return stats
+
+
+def print_stats(stats):
+
+    print('Processed: {:,}'.format(stats['processed']))
+    print('Deleted Items: {:,}'.format(stats['deleted_items']))
+    print('Deleted Sets: {:,}'.format(stats['deleted_sets']))
+    print('Deleted %: {:.2f}'.format(
+        ((stats['deleted_items'] + stats['deleted_sets']) / float(stats['processed'])) * 100
+    ))
+    print('Bytes per second: {}'.format(sizeof_fmt(stats['bps'])))
+    print('Items per second: {:.2f}'.format(stats['ips']))
+    print('Errors: {:,}'.format(stats['errors']))
+    print('Pages: {:,}'.format(stats['pages']))
+    print('Freed: {}'.format(sizeof_fmt(stats['bytes'])))
+    print('Time: {}'.format(pretty_time_delta(stats['runtime'])))
+    print('')
+
+
+def log_stats(stats):
+    logger.info(json.dumps(stats))
+
+
+class Command(BaseCommand):
+    help = 'Cleanup expired invalidation structures'
+    option_list = BaseCommand.option_list + (
+        make_option(
+            '--pages',
+            dest='pages',
+            help='Max number of pages to use when calling the scan comands',
+        ),
+        make_option(
+            '--page-size',
+            dest='page_size',
+            action='store',
+            default=1000,
+            help='Page size to use when calling the scan comands',
+        ),
+        make_option(
+            '--conj',
+            dest='conj',
+            help='The conj set to process',
+        ),
+        make_option(
+            '--interval',
+            dest='interval',
+            default=.100,
+            help='The time to wait between sweeps.',
+        ),
+        make_option(
+            '--wait-pages',
+            dest='wait_pages',
+            action='store',
+            default=100,
+            help='Number of pages to process before sleeping',
+        ),
+        make_option(
+            '--host',
+            dest='host',
+            help='Override the host setting.',
+        ),
+    )
+
+    def handle(self, *args, **options):
+
+        pages = options['pages']
+        if pages is not None:
+            pages = int(pages)
+
+        page_size = int(options['page_size'])
+        wait_pages = int(options['wait_pages'])
+        interval = float(options['interval'])
+        verbosity = options['verbosity'] > 1
+
+        if options['conj']:
+            stats = gc_conj_key(options['conj'], pages, page_size, interval, wait_pages)
+            print_stats(stats)
+        else:
+            if not settings.CACHEOPS_LRU:
+                print('This script is only required when CACHEOPS_LRU is enabled', file=sys.stderr)
+                sys.exit(1)
+
+            if options['host']:
+                settings.CACHEOPS_REDIS['host'] = options['host']
+
+            stats = gc(pages, page_size, interval, verbosity, wait_pages)
+            if verbosity:
+                print_stats(stats)
+            else:
+                log_stats(stats)

--- a/cacheops/management/commands/cacheops_top.py
+++ b/cacheops/management/commands/cacheops_top.py
@@ -1,0 +1,165 @@
+from __future__ import absolute_import, print_function
+
+import sys
+import time
+
+from optparse import make_option
+
+from django.core.management.base import BaseCommand
+
+from cacheops.redis import redis_client
+from cacheops.management.util import pretty_time_delta, sizeof_fmt
+
+
+def largest_sets(display_count, max_pages, page_size):
+
+    cards = []
+    start_time = time.time()
+    current_min = 0
+
+    conj_keys = redis_client.scan_iter(match='conj:*', count=page_size)
+    for sampled, conj_key in enumerate(conj_keys, 1):
+        card = redis_client.scard(conj_key)
+
+        if len(cards) < display_count:
+            cards.append((card, conj_key))
+            if current_min == 0:
+                current_min = card
+            else:
+                current_min = min(current_min, card)
+        elif card > current_min:
+            replace = None
+            for i, size in enumerate(cards):
+                if size[0] < card:
+                    replace = i
+                    break
+            if replace is not None:
+                cards[replace] = (card, conj_key)
+                current_min = min(current_min, card)
+
+        pages = sampled / page_size
+
+        if sampled % page_size == 0:
+            print_largest_sets(cards, sampled, pages, start_time)
+
+        if max_pages and pages > max_pages:
+            break
+
+    print_largest_sets(cards, sampled, pages, start_time)
+
+def print_largest_sets(cards, sampled, pages, start_time):
+    for i, item in enumerate(sorted(cards, reverse=True), 1):
+        print('{:<3} {} {:,}'.format(str(i) + ')', item[1], item[0]))
+
+    print('\nkeys={:,} pages={:,} in {}'.format(
+        sampled,
+        pages,
+        pretty_time_delta(time.time() - start_time),
+    ))
+
+
+def largest_keys(display_count, max_pages, page_size):
+
+    sizes = []
+    current_min = 0
+    pages = 0
+    total_bytes = 0
+
+    keys = redis_client.scan_iter(match='q:*', count=page_size)
+    for sampled, key in enumerate(keys, 1):
+        data = redis_client.get(key)
+        if data is None:
+            continue
+        data_len = len(data)
+
+        total_bytes += data_len
+
+        if len(sizes) < display_count:
+            sizes.append((data_len, key))
+            if current_min == 0:
+                current_min = data_len
+            else:
+                current_min = min(current_min, data_len)
+        elif data_len > current_min:
+            replace = None
+            for i, size in enumerate(sizes):
+                if size[0] < data_len:
+                    replace = i
+                    break
+            if replace is not None:
+                sizes[replace] = (data_len, key)
+                current_min = min(current_min, data_len)
+
+        pages = sampled / page_size
+
+        if sampled % page_size == 0:
+            print_largest_keys(sizes, sampled, pages, total_bytes, total_bytes / sampled)
+
+        if max_pages and pages > max_pages:
+            break
+
+    print_largest_keys(sizes, sampled, pages, total_bytes, total_bytes / sampled)
+
+
+def print_largest_keys(sizes, sampled, pages, total_bytes, avg):
+    for i, item in enumerate(sorted(sizes, reverse=True), 1):
+        print('{:<3} {} {}'.format(str(i) + ')', item[1], sizeof_fmt(item[0])))
+    print('\nAverage key size: {}'.format(sizeof_fmt(avg)))
+    print('{:,} keys {} sampled in {:,} pages'.format(sampled, sizeof_fmt(total_bytes), pages))
+
+
+class Command(BaseCommand):
+    help = 'Cleanup expired invalidation structures'
+    option_list = BaseCommand.option_list + (
+        make_option(
+            '--pages',
+            dest='pages',
+            help='Max number of pages to use when calling the scan comands',
+        ),
+        make_option(
+            '--page-size',
+            dest='page_size',
+            default=1000,
+            help='Page size to use when calling the scan comands',
+        ),
+        make_option(
+            '--keys',
+            dest='keys',
+            action='store_true',
+            help='Find the largest keys',
+        ),
+        make_option(
+            '--sets',
+            dest='sets',
+            action='store_true',
+            help='Find the largest keys',
+        ),
+        make_option(
+            '--display',
+            dest='display',
+            default=20,
+            help='Set the number of items to display',
+        ),
+        make_option(
+            '--host',
+            dest='host',
+            help='Override the host setting.',
+        ),
+    )
+
+    def handle(self, *args, **options):
+
+        pages = options['pages']
+        if pages is not None:
+            pages = int(pages)
+
+        display_count = int(options['display'])
+        page_size = int(options['page_size'])
+
+        if options['sets']:
+            largest_sets(display_count, pages, page_size)
+        elif options['keys']:
+            largest_keys(display_count, pages, page_size)
+        else:
+            print('Must specify --keys or --sets', file=sys.stderr)
+            sys.exit(1)

--- a/cacheops/management/util.py
+++ b/cacheops/management/util.py
@@ -1,0 +1,22 @@
+def sizeof_fmt(num, suffix='B'):
+    for unit in ['', 'Ki', 'Mi', 'Gi', 'Ti', 'Pi', 'Ei', 'Zi']:
+        if abs(num) < 1024.0:
+            return "%3.1f%s%s" % (num, unit, suffix)
+        num /= 1024.0
+    return "%.1f%s%s" % (num, 'Yi', suffix)
+
+
+def pretty_time_delta(seconds):
+    # https://gist.github.com/thatalextaylor/7408395
+    int_seconds = int(seconds)
+    milliseconds = seconds - int_seconds
+    days, seconds = divmod(int_seconds, 86400)
+    hours, seconds = divmod(int_seconds, 3600)
+    minutes, seconds = divmod(int_seconds, 60)
+    if days > 0:
+        return '{}d{}h{}m{}s{:0.2f}ms'.format(days, hours, minutes, seconds, milliseconds)
+    if hours > 0:
+        return '{}h{}m{}s{:0.2f}ms'.format(hours, minutes, seconds, milliseconds)
+    if minutes > 0:
+        return '{}m{}s{:0.2f}ms'.format(minutes, seconds, milliseconds)
+    return '{}s{:0.2f}ms'.format(seconds, milliseconds)


### PR DESCRIPTION
If CACHEOPS_LRU is enabled CacheOps will not reap its invalidation structures. For example:

```
> SCARD conj:auth_user:is_active=true
(integer) 2851530
```

Shows that the set contains about 3m members. Checking one of the keys from the set:

```
> SSCAN "conj:auth_user:is_active=true" 0 COUNT 10
1) "1179648"
2)  1) "q:e0ab9bf9f2e1f1475f663bfe8a50269f"
    2) "q:b09c2d45f348a19578154fcbdd1c07d6"
    3) "as:6a89b161b51cedb7cea37c8e51480465"
    4) "q:cc6c466aef5822649fce5ed738646bb4"
    5) "q:9036ac3b3880fb47f36e37451837eec2"
    6) "q:5c8903f26de59ba20e47bbf7f0a7e70a"
    7) "q:8694b66aad2186e03b940580f8d1b00c"
    8) "q:a083362753b9c5e986f3c10c0dddc19d"
    9) "q:1e13437f509ab6bb8ad51ab19d30f1d9"
   10) "q:e19c6b853a0f979bd28f65bc2c705b85"
   11) "q:5f02f2160186282d111fa18722ece7ed"
> EXISTS "q:e0ab9bf9f2e1f1475f663bfe8a50269f"
(integer) 0
```

Shows that the key has been expired by cacheops but has NOT been removed from the set. This script will iterate through all the conjuction sets and call SREM on the the members that do not exist.

Below is the current output from the `cacheops_lru_gc` when it has completed:

```
Processed: 71,349,660
Deleted Items: 57,674,051
Deleted Sets: 11,637,743
Deleted %: 97.14
Bytes per second: 89.3KiB
Items per second: 2519.46
Errors: 0
Pages: 12,373,159
Freed: 2.4GiB
Time: 7h471m59s0.46ms
```

The `cacheops_top` command will show the top 20 keys with largest values (pickled querysets) or the top 20 sets with the most number of members. Depending on whether `--keys` or `--sets` is passed.
